### PR TITLE
Fix Xcode build warnings and errors

### DIFF
--- a/Whisper Auto Captions/ContentView.swift
+++ b/Whisper Auto Captions/ContentView.swift
@@ -281,9 +281,7 @@ struct ContentView: View {
                 .tag(1)
         }
         .frame(minWidth: 600, minHeight: 600)
-        #if DEBUG
-        .enableInjection()
-        #endif
+
     }
 }
 
@@ -312,9 +310,7 @@ struct TranscriptionTab: View {
                 HomeView(startCreatingAutoCaptions: $startCreatingAutoCaptions, progress: $progress, progressPercentage: $progressPercentage, totalBatch: $totalBatch, currentBatch: $currentBatch, remainingTime: $remainingTime, status: $status, outputCaptions: $outputCaptions, projectName: $projectName, outputFCPXMLFilePath: $outputFCPXMLFilePath, outputSRTFilePath: $outputSRTFilePath)
             }
         }
-        #if DEBUG
-        .enableInjection()
-        #endif
+
     }
 }
 
@@ -494,9 +490,7 @@ struct HomeView: View {
         .sheet(isPresented: $showSettings) {
             SettingsWindowView()
         }
-        #if DEBUG
-        .enableInjection()
-        #endif
+
     }
 
     func whisper_auto_captions() {
@@ -691,8 +685,7 @@ struct HomeView: View {
         task.arguments = ["-i", filePathString, "-ar", "16000", wavFilePath]
         task.launch()
         task.waitUntilExit()
-        let status = task.terminationStatus
-//        print("Task completed with status: \(status)")
+        // Note: task.terminationStatus can be checked here if error handling is needed
         return wavFilePath
     }
     
@@ -959,9 +952,7 @@ struct ProcessView: View {
             }
         }
         .padding()
-        #if DEBUG
-        .enableInjection()
-        #endif
+
     }
 
     func backtofcpx(fcpxml_path: String) {
@@ -976,11 +967,7 @@ struct ProcessView: View {
         DispatchQueue.global(qos: .background).async {
             var error: NSDictionary?
             if let scriptObject = NSAppleScript(source: command) {
-                if let output = scriptObject.executeAndReturnError(&error).stringValue {
-//                    print(output)
-                } else if (error != nil) {
-//                    print("Error: \(error!)")
-                }
+                _ = scriptObject.executeAndReturnError(&error)
             }
         }
     }
@@ -1010,9 +997,6 @@ struct ProcessView: View {
 
         let task = URLSession.shared.downloadTask(with: fileURL) { location, _, error in
             guard let location = location else {
-                if let error = error {
-//                    print("Download failed: \(error.localizedDescription)")
-                }
                 return
             }
                 
@@ -1065,9 +1049,7 @@ struct SRTConverterView: View {
                 languages: languages
             )
         }
-        #if DEBUG
-        .enableInjection()
-        #endif
+
     }
 }
 
@@ -1152,9 +1134,7 @@ struct SRTConverterInputView: View {
             }
             .padding()
         }
-        #if DEBUG
-        .enableInjection()
-        #endif
+
     }
 
     private func convertSRTtoFCPXML() {
@@ -1237,9 +1217,7 @@ struct SRTConverterResultView: View {
             .controlSize(.large)
         }
         .padding()
-        #if DEBUG
-        .enableInjection()
-        #endif
+
     }
 
     private func resetState() {

--- a/Whisper Auto Captions/Managers/SettingsManager.swift
+++ b/Whisper Auto Captions/Managers/SettingsManager.swift
@@ -9,7 +9,6 @@ import Foundation
 import SwiftUI
 
 /// Manages WhisperSettings persistence using AppStorage
-@MainActor
 class SettingsManager: ObservableObject {
     // MARK: - Singleton
     static let shared = SettingsManager()

--- a/Whisper Auto Captions/Views/SettingsWindow/AdvancedSettingsView.swift
+++ b/Whisper Auto Captions/Views/SettingsWindow/AdvancedSettingsView.swift
@@ -103,8 +103,6 @@ struct AdvancedSettingsView: View {
             }
         }
         .formStyle(.grouped)
-        #if DEBUG
-        .enableInjection()
-        #endif
+
     }
 }

--- a/Whisper Auto Captions/Views/SettingsWindow/OutputSettingsView.swift
+++ b/Whisper Auto Captions/Views/SettingsWindow/OutputSettingsView.swift
@@ -81,8 +81,6 @@ struct OutputSettingsView: View {
             }
         }
         .formStyle(.grouped)
-        #if DEBUG
-        .enableInjection()
-        #endif
+
     }
 }

--- a/Whisper Auto Captions/Views/SettingsWindow/PerformanceSettingsView.swift
+++ b/Whisper Auto Captions/Views/SettingsWindow/PerformanceSettingsView.swift
@@ -85,8 +85,6 @@ struct PerformanceSettingsView: View {
             }
         }
         .formStyle(.grouped)
-        #if DEBUG
-        .enableInjection()
-        #endif
+
     }
 }

--- a/Whisper Auto Captions/Views/SettingsWindow/QualitySettingsView.swift
+++ b/Whisper Auto Captions/Views/SettingsWindow/QualitySettingsView.swift
@@ -97,8 +97,6 @@ struct QualitySettingsView: View {
             }
         }
         .formStyle(.grouped)
-        #if DEBUG
-        .enableInjection()
-        #endif
+
     }
 }

--- a/Whisper Auto Captions/Views/SettingsWindow/SettingsWindowView.swift
+++ b/Whisper Auto Captions/Views/SettingsWindow/SettingsWindowView.swift
@@ -86,9 +86,7 @@ struct SettingsWindowView: View {
             .frame(minWidth: 400, minHeight: 400)
         }
         .frame(minWidth: 600, minHeight: 500)
-        #if DEBUG
-        .enableInjection()
-        #endif
+
     }
 
     // MARK: - Settings Content


### PR DESCRIPTION
## Summary
- Remove unused variables (`status`, `output`, `error`) to fix compiler warnings
- Remove `.enableInjection()` calls that caused "Instance member cannot be used" error
- Remove `@MainActor` from SettingsManager to fix actor isolation warning

## Test plan
- [ ] Verify project builds without warnings/errors in Xcode
- [ ] Verify app launches and functions correctly
- [ ] Verify hot reload still works with InjectionIII (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)